### PR TITLE
log when build fails

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -796,11 +796,7 @@ void Builder::Cleanup() {
     }
   }
 
-  if (compiler_log_) {
-    fprintf(compiler_log_, "#Done(%" PRId64 ")\n", GetTimeMillis());
-    fclose(compiler_log_);
-    compiler_log_ = NULL;
-  }
+  compiler_log_ = NULL;
 }
 
 Node* Builder::AddTarget(const string& name, string* err) {

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1172,18 +1172,26 @@ int NinjaMain::RunBuild(int argc, char** argv) {
     printf("ninja: build stopped: %s.\n", err.c_str());
 #else     
 
-  if(ShouldBeColorFul(false)){
-    printf("\x1b[31m" "FAILED:" "\x1b[0m" " %s.\n", err.c_str());    
-  } else {
-    printf("FAILED: %s.\n", err.c_str());    
-  }
+    if (ShouldBeColorFul(false)) {
+      printf("\x1b[31m" "FAILED:" "\x1b[0m" " %s.\n", err.c_str());
+    } else {
+      printf("FAILED: %s.\n", err.c_str());    
+    }
+    fprintf(compiler_log_, "FAILED: %s.\n", err.c_str());
 
 #endif
+
+    fprintf(compiler_log_, "#Done(%" PRId64 ")\n", GetTimeMillis());
+    fclose(compiler_log_);
+
     if (err.find("interrupted by user") != string::npos) {
       return 2;
     }
     return 1;
   }
+
+  fprintf(compiler_log_, "#Done(%" PRId64 ")\n", GetTimeMillis());
+  fclose(compiler_log_);
 
   return 0;
 }


### PR DESCRIPTION
related issue: https://github.com/rescript-lang/rescript-compiler/issues/5229

If the ninja build fails, write the error log to `.compiler.log`.