### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name:  CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ dev, g_rescript ]
+  pull_request:
+    branches: [ dev, g_rescript ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: ninja
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: "Windows: Use MSVC"
+      if: runner.os == 'Windows'
+      uses: TheMrMilchmann/setup-msvc-dev@v1
+      with:
+        arch: x64
+
+    - name: Run snapshot.js
+      run: |
+        node createBinDir.js
+        node snapshot.js
+      working-directory: ninja
+
+    - name: Get artifact info
+      id: get_artifact_info
+      run: node ninja/.github/workflows/get_artifact_info.js
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.get_artifact_info.outputs.artifact_name }}
+        path: ${{ steps.get_artifact_info.outputs.artifact_path }}

--- a/.github/workflows/get_artifact_info.js
+++ b/.github/workflows/get_artifact_info.js
@@ -1,0 +1,10 @@
+const artifactPath =
+  process.platform === "darwin"
+    ? process.platform + process.arch
+    : process.platform;
+
+const artifactName = "ninja-" + artifactPath;
+
+// Pass artifactPath and artifactName to subsequent GitHub actions
+console.log(`::set-output name=artifact_path::${artifactPath}`);
+console.log(`::set-output name=artifact_name::${artifactName}`);

--- a/createBinDir.js
+++ b/createBinDir.js
@@ -1,0 +1,12 @@
+// Create bin dir for CI
+
+const fs = require("fs");
+const path = require("path");
+
+const platform = process.platform;
+const arch = process.arch;
+
+const binDir = platform === "darwin" ? platform + arch : platform;
+const binPath = path.join(__dirname, "..", binDir);
+
+fs.mkdirSync(binPath);


### PR DESCRIPTION
This adds CI (Github Actions) to this repo, including artifact upload for the ninja binary for all supported platforms.
On Windows, the MSVC compiler is used.

I have successfully tested this in my fork of the repo, as the workflow did not run in this one, maybe because the ci.yml needs to exist in the target branch first.

BTW, I don't understand the branch setup in this repo. `dev` is set as the default branch, 
but `g_rescript` is the up to date one used for building the ninja binary for the current rescript-compiler master.
I am therefore targeting `g_rescript` in this PR, but have added both branches in the CI.yml.

<img width="444" alt="Bildschirmfoto 2022-05-26 um 07 08 43" src="https://user-images.githubusercontent.com/591384/170420111-4621b61e-0cb4-4650-bf8b-df0376331b93.png">